### PR TITLE
fix: copy stack from ingredient before modifying it

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbjeiextras/modspecific/GlodiumHelpers.java
+++ b/src/main/java/dev/ftb/mods/ftbjeiextras/modspecific/GlodiumHelpers.java
@@ -4,6 +4,9 @@ import com.glodblock.github.glodium.recipe.stack.IngredientStack;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 public class GlodiumHelpers {
     public static Ingredient of(IngredientStack.Item stack) {
         if (stack.isEmpty()) {
@@ -11,11 +14,8 @@ public class GlodiumHelpers {
         }
 
         Ingredient ingredient = stack.getIngredient();
-        ItemStack[] items = ingredient.getItems();
-        for (ItemStack item : items) {
-            item.setCount(stack.getAmount());
-        }
+        Stream<ItemStack> stacks = Arrays.stream(ingredient.getItems()).map(oldStack -> oldStack.copyWithCount(stack.getAmount()));
 
-        return Ingredient.of(items);
+        return Ingredient.of(stacks);
     }
 }


### PR DESCRIPTION
Hello, I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod that relies heavily on modders to not modify the inner stack of those ingredients.

I would greatly appreciate it if you could accept this PR.

Thanks.